### PR TITLE
Remove dead instances from subs

### DIFF
--- a/src/bus.ts
+++ b/src/bus.ts
@@ -229,7 +229,7 @@ export class MessageBus {
       return;
     }
 
-    subList.subs.filter((sub) => sub.id !== id);
+    subList.subs = subList.subs.filter((sub) => sub.id !== id);
 
     if (subList.subs.length < 1) {
       await this.#subscriber.unsubscribe(topic);


### PR DESCRIPTION
We were not properly unsubscribing from instances and for queued messages, there's a chance we were attempting to deliver messages to the void